### PR TITLE
Revamp podSelector for netpol

### DIFF
--- a/varnish-cache/templates/networkpolicy.yaml
+++ b/varnish-cache/templates/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ .Release.Name }}
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
instance is too global, the goal is simply to limit it to varnish pods